### PR TITLE
Fix async call to fetch player profile

### DIFF
--- a/backend/api/routers/tournaments.py
+++ b/backend/api/routers/tournaments.py
@@ -37,7 +37,7 @@ async def create_tournament(
     """Create a new tournament."""
     try:
         # Get player profile to determine ranking
-        player_profile = player_service.get_player_profile(current_user["id"])
+        player_profile = await player_service.get_player_by_user_id(current_user["id"])
         if not player_profile:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,


### PR DESCRIPTION
## Summary
- await PlayerProfileService in tournament creation

## Testing
- `npm run test` *(fails: Missing script "test" in frontend workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68669c5dd73c8330ade302983ba5902d