### PR TITLE
Fix supabase key variable docs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -16,7 +16,7 @@ Per utilizzare il workflow di deploy automatico, è necessario configurare i seg
 - `POSTGRES_URL`: URL di connessione al database PostgreSQL su Supabase
 - `DATABASE_URL`: URL di connessione al database (stesso valore di POSTGRES_URL)
 - `SUPABASE_URL`: URL del progetto Supabase
-- `SUPABASE_KEY`: Chiave API di Supabase
+ - `SUPABASE_SERVICE_ROLE_KEY`: Chiave API di Supabase
 - `JWT_SECRET`: Chiave segreta per la generazione dei token JWT
 - `SMTP_HOST`: Host del server SMTP per l'invio di email
 - `SMTP_PORT`: Porta del server SMTP
@@ -38,7 +38,7 @@ Per utilizzare il workflow di deploy automatico, è necessario configurare i seg
 
 ### Come ottenere i segreti Supabase
 
-1. **SUPABASE_URL e SUPABASE_KEY**:
+1. **SUPABASE_URL e SUPABASE_SERVICE_ROLE_KEY**:
    - Vai su https://app.supabase.io/
    - Seleziona il tuo progetto
    - Vai su Settings > API
@@ -70,7 +70,7 @@ Il backend utilizza PostgreSQL su Supabase come database. La connessione è conf
    DATABASE_URL=postgresql://postgres:postgres@db.solcraftl2.supabase.co:5432/postgres
    POSTGRES_URL=postgresql://postgres:postgres@db.solcraftl2.supabase.co:5432/postgres
    SUPABASE_URL=https://db.solcraftl2.supabase.co
-   SUPABASE_KEY=your-supabase-key
+   SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
    JWT_SECRET=your-jwt-secret
    SMTP_HOST=smtp.example.com
    SMTP_PORT=587

--- a/backend/test_deploy_completo.md
+++ b/backend/test_deploy_completo.md
@@ -6,5 +6,5 @@ Questo file è stato creato per testare la pipeline di deploy automatico con tut
 - DATABASE_URL
 - JWT_SECRET
 - SUPABASE_URL
-- SUPABASE_KEY
+- SUPABASE_SERVICE_ROLE_KEY
 Data: Sun Jun  8 09:45:24 EDT 2025

--- a/backend/test_deploy_segreti.md
+++ b/backend/test_deploy_segreti.md
@@ -3,6 +3,6 @@ Questo file è stato creato per testare il deploy automatico dopo la configurazi
 - postgres_url
 - database_url
 - supabase_url
-- supabase_key
+- supabase_service_role_key
 - jwt_secret
 Data: Sun Jun  8 10:33:55 EDT 2025


### PR DESCRIPTION
## Summary
- update backend README to use `SUPABASE_SERVICE_ROLE_KEY`
- update deploy docs to reference `SUPABASE_SERVICE_ROLE_KEY`

## Testing
- `npm run test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669c5ebdcc8330865c2e87b33abc38