### PR TITLE
Fix Tailwind config content paths

### DIFF
--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -4,9 +4,9 @@ import type {Config} from 'tailwindcss';
 export default {
   darkMode: ['class'],
   content: [
-    './sol-craft/src/pages/**/*.{js,ts,jsx,tsx,mdx}',
-    './sol-craft/src/components/**/*.{js,ts,jsx,tsx,mdx}',
-    './sol-craft/src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- fix paths in `frontend/tailwind.config.ts` so Tailwind scans the `src` folder

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68669c5f3a4883308fec399091ac4eeb