### PR TITLE
Add frontend env example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ backend/build/
 .env.test.local
 .env.production.local
 frontend/.env*
+!frontend/.env.example
 backend/.env*
 
 # IDE

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,15 @@
+# Example environment variables for SolCraft Frontend
+# Copy this file to `.env` and fill in your real credentials.
+
+# --- Server-Side Firebase Admin Configuration ---
+GOOGLE_APPLICATION_CREDENTIALS=path/to/your-service-account.json
+FIREBASE_PROJECT_ID=your-firebase-project-id
+
+# --- Client-Side Firebase Configuration ---
+NEXT_PUBLIC_FIREBASE_API_KEY=your-firebase-api-key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-auth-domain
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-firebase-project-id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-storage-bucket
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your-messaging-sender-id
+NEXT_PUBLIC_FIREBASE_APP_ID=your-app-id
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=your-measurement-id


### PR DESCRIPTION
## Summary
- provide an example env file for the frontend
- keep real env files ignored but track the example

## Testing
- `npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_686bf825ecd08330ba7805f48dd797c2