### PR TITLE
Resolve backend framework conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Questo repository contiene l'intera piattaforma SolCraft Poker, organizzata come
 ```
 solcraft-poker/
 ├── frontend/          # Applicazione Next.js (React + TypeScript)
-├── backend/           # API Python (FastAPI/Flask)
+├── backend/           # API Python (FastAPI)
 ├── README.md          # Questo file
 ├── package.json       # Configurazione workspace
 └── .gitignore         # File da ignorare

--- a/backend/README.md
+++ b/backend/README.md
@@ -56,7 +56,7 @@ Il backend utilizza PostgreSQL su Supabase come database. La connessione è conf
 
 ## Struttura del Progetto
 
-- `/api`: Endpoint API Flask
+- `/api`: Endpoint API FastAPI
 - `/models`: Modelli di dati
 - `/services`: Logica di business
 - `/utils`: Utility e helper functions
@@ -77,4 +77,4 @@ Il backend utilizza PostgreSQL su Supabase come database. La connessione è conf
    SMTP_USER=your-smtp-user
    SMTP_PASS=your-smtp-password
    ```
-4. Avvia il server di sviluppo: `vercel dev`
+4. Avvia il server di sviluppo: `python main.py`

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "builds": [
     {
-      "src": "api/index.py",
+      "src": "main.py",
       "use": "@vercel/python"
     },
     {
@@ -17,11 +17,11 @@
     },
     {
       "src": "/api",
-      "dest": "/api/index.py"
+      "dest": "/main.py"
     },
     {
       "src": "/api/(.*)",
-      "dest": "/api/index.py"
+      "dest": "/main.py"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- standardize backend to FastAPI
- update README docs to mention FastAPI only
- update backend README to run FastAPI server
- configure `vercel.json` to serve `main.py`

## Testing
- `pip install flake8`
- `npm run lint:backend`

------
https://chatgpt.com/codex/tasks/task_e_686bf82805f483309f496e51d03e6da7