### PR TITLE
Address TODOs and document pending work

### DIFF
--- a/TODO_TASKS.md
+++ b/TODO_TASKS.md
@@ -1,0 +1,19 @@
+# Outstanding TODO Items
+
+This document tracks TODO comments found in the repository. Each item lists the file and a short description of the work required.
+
+## Implemented
+- **frontend/src/app/launchtoken/page.tsx** – Added filtering logic for search, status and category.
+
+## Pending Tasks
+- **.git/hooks/sendemail-validate.sample** – Sample hook contains placeholder checks. Decide whether to customize or remove this sample file.
+- **frontend_backup/src/services/extendedApiService.ts** – Implement backend endpoints for:
+  - user profile retrieval and updates
+  - investment CRUD actions
+  - liquidity/volume/overview chart data
+  - wallet connect/disconnect
+  - tournament participation
+- **frontend_backup/src/components/investment/investment-table.tsx** – Hook up user investment endpoint in `loadInvestments`.
+- **frontend_backup/src/components/screens/solcraft-dashboard.tsx** – Load actual user portfolio and include organizer and participant data when transforming tournaments. Replace placeholder ROI calculation.
+- **frontend_backup/src/components/tournament/tournament-table.tsx** – Populate organizer, participant counts, real ROI and organizer rating from backend data.
+

--- a/frontend/src/app/launchtoken/page.tsx
+++ b/frontend/src/app/launchtoken/page.tsx
@@ -19,11 +19,34 @@ export default function LaunchTokenPage() {
   const [statusFilter, setStatusFilter] = useState('all');
   const [categoryFilter, setCategoryFilter] = useState('all');
 
-  // TODO: Implement actual filtering logic based on searchTerm, statusFilter, categoryFilter
-  const featuredLaunches = mockTokenLaunches.filter(launch => launch.isFeatured && (launch.stage === 'Live' || launch.stage === 'Upcoming')).slice(0, 2);
-  const liveLaunches = mockTokenLaunches.filter(launch => launch.stage === 'Live' && !launch.isFeatured);
-  const upcomingLaunches = mockTokenLaunches.filter(launch => launch.stage === 'Upcoming' && !launch.isFeatured);
-  const pastLaunches = mockTokenLaunches.filter(launch => launch.stage === 'Ended');
+  // Filter launches based on search input and dropdown selections
+  const filteredLaunches = mockTokenLaunches.filter((launch) => {
+    const matchesSearch =
+      searchTerm.trim() === '' ||
+      launch.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      launch.ticker.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesStatus =
+      statusFilter === 'all' || launch.stage === statusFilter;
+    const matchesCategory =
+      categoryFilter === 'all' || launch.category === categoryFilter;
+    return matchesSearch && matchesStatus && matchesCategory;
+  });
+
+  const featuredLaunches = filteredLaunches
+    .filter(
+      (launch) =>
+        launch.isFeatured && (launch.stage === 'Live' || launch.stage === 'Upcoming')
+    )
+    .slice(0, 2);
+  const liveLaunches = filteredLaunches.filter(
+    (launch) => launch.stage === 'Live' && !launch.isFeatured
+  );
+  const upcomingLaunches = filteredLaunches.filter(
+    (launch) => launch.stage === 'Upcoming' && !launch.isFeatured
+  );
+  const pastLaunches = filteredLaunches.filter(
+    (launch) => launch.stage === 'Ended'
+  );
 
   const allCategories = Array.from(new Set(mockTokenLaunches.map(l => l.category).filter(Boolean))) as string[];
 


### PR DESCRIPTION
## Summary
- implement filtering on Launch Token page
- record all remaining TODOs in `TODO_TASKS.md`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf8284fc8833098743149ec3f9957