### PR TITLE
Install flake8 for backend lint script

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -27,3 +27,6 @@ Flask-CORS==4.0.0
 pytest==7.4.3
 pytest-asyncio==0.21.1
 
+# Linting
+flake8==6.1.0
+


### PR DESCRIPTION
## Summary
- add `flake8` to `backend/requirements.txt`

## Testing
- `pip install -r backend/requirements.txt`
- `npm run lint:backend` *(fails: flake8 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686bf829579483308937aa7fa33fdf03