### PR TITLE
Clarify database authority and migrate actions to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ solcraft-poker/
 
 ### Backend (`/backend`)
 - **Framework**: Python con FastAPI
-- **Database**: PostgreSQL/MongoDB
+ - **Database**: Supabase (PostgreSQL)
+ - **Database Authoritative**: Tutti i dati principali risiedono su Supabase; Firestore viene utilizzato solo per funzionalità client-side.
 - **Funzionalità**:
   - API REST per frontend
   - Gestione utenti e autenticazione

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,6 +2,9 @@
 
 Backend per la piattaforma di tokenizzazione SolCraft L2 su blockchain Solana.
 
+## Database Authoritativo
+Supabase (PostgreSQL) è la fonte di verità per tutti i dati persistenti. Il frontend utilizza Firebase unicamente per l'autenticazione e lo storage dei file.
+
 ## Configurazione Deploy con GitHub Actions
 
 Questo repository è configurato per il deploy automatico su Vercel tramite GitHub Actions. Il workflow è definito nel file `.github/workflows/vercel-deploy.yml`.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -45,7 +45,7 @@ SolCraft aims to be a user-friendly yet powerful platform for both new and exper
 *   **UI Components:** ShadCN UI
 *   **Styling:** Tailwind CSS
 *   **AI Integration:** Genkit (for Google AI models like Gemini)
-*   **Backend/Database:** Firebase (Authentication, Firestore, Storage)
+*   **Backend API & Database:** Supabase (PostgreSQL) tramite FastAPI. Firebase gestisce Autenticazione e Storage.
 *   **State Management:** React Context API, `useState`, `useEffect`
 *   **Forms:** React Hook Form with Zod for validation
 *   **Charting:** Recharts (via ShadCN Charts)
@@ -182,7 +182,7 @@ Genkit is used for integrating AI capabilities, such as the tournament risk asse
 
 ## Firebase Integration
 
-Firebase is used for backend services: Authentication, Firestore database, and Storage for file uploads.
+Firebase provides Authentication and Storage. Tutti i dati persistenti sono gestiti tramite Supabase attraverso le API del backend.
 
 ## Available Scripts
 

--- a/frontend/src/lib/actions/investment.actions.ts
+++ b/frontend/src/lib/actions/investment.actions.ts
@@ -1,13 +1,11 @@
 
 'use server';
 
-import { getAdminDb } from '@/lib/firebaseAdmin';
-import { FieldValue } from 'firebase-admin/firestore';
 import { revalidatePath } from 'next/cache';
+import { apiCall, API_ENDPOINTS } from '@/lib/api-config';
 import type { Investment } from '../types';
 
 export async function makeInvestment(userId: string, details: { tournamentId: string, tournamentName: string, tierName: string, amount: number, tokenAmount: number }) {
-  const adminDb = getAdminDb();
   if (!userId || !details || !details.tournamentId || details.amount <= 0) {
     return { success: false, message: 'Invalid investment data provided.' };
   }
@@ -24,33 +22,9 @@ export async function makeInvestment(userId: string, details: { tournamentId: st
   };
 
   try {
-    const userRef = adminDb.collection('users').doc(userId);
-    const investmentRef = adminDb.collection('investments').doc(); // Auto-generate ID
-
-    // Note: The 'tournaments' collection is conceptual and based on mock data.
-    // In a real app, this would update a live document. This may not find a doc
-    // if one doesn't exist in your actual Firestore DB. We will proceed assuming it might.
-    const tournamentRef = adminDb.collection('tournaments').doc(details.tournamentId);
-
-    // Using a transaction to ensure all writes succeed or none do.
-    await adminDb.runTransaction(async (transaction) => {
-        // 1. Create the new investment document
-        transaction.set(investmentRef, investmentData);
-        
-        // 2. Update user's total invested amount
-        transaction.update(userRef, {
-            totalInvested: FieldValue.increment(details.amount)
-        });
-
-        // 3. Update the tournament's raised amount
-        // This part is likely to fail if the tournament doc doesn't exist in Firestore.
-        // For robustness, we check its existence first, but this is a common issue with mock-first dev.
-        const tournamentDoc = await transaction.get(tournamentRef);
-        if (tournamentDoc.exists) {
-            transaction.update(tournamentRef, {
-                raisedAmount: FieldValue.increment(details.amount)
-            });
-        }
+    await apiCall(`${API_ENDPOINTS.tournamentById(details.tournamentId)}/invest`, {
+      method: 'POST',
+      body: JSON.stringify({ userId, amount: details.amount, tierName: details.tierName }),
     });
 
     // Revalidate paths to reflect updated data
@@ -60,12 +34,7 @@ export async function makeInvestment(userId: string, details: { tournamentId: st
 
     return { success: true, message: 'Investment was successful!' };
   } catch (error) {
-    console.error('Error making investment:', error);
-    // Check if the error is because the tournament doc doesn't exist.
-    // This is a common issue when working with mock data that might not be in the DB.
-    if ((error as any).code === 5) { // Firestore's NOT_FOUND error code
-         return { success: false, message: 'Your investment could not be processed because the tournament record was not found in the database.' };
-    }
+    console.error('Error making investment via API:', error);
     return { success: false, message: 'Your investment could not be processed due to a server error.' };
   }
 }

--- a/frontend/src/lib/actions/support.actions.ts
+++ b/frontend/src/lib/actions/support.actions.ts
@@ -1,10 +1,9 @@
 
 'use server';
-import { getAdminDb } from '@/lib/firebaseAdmin';
 import type { SupportTicket } from '../types';
+import { apiCall, API_ENDPOINTS } from '@/lib/api-config';
 
 export async function submitSupportTicket(formData: {name: string, email: string, subject: string, message: string}, userId?: string) {
-    const adminDb = getAdminDb();
     const ticketData: SupportTicket = {
         name: formData.name,
         email: formData.email,
@@ -19,10 +18,13 @@ export async function submitSupportTicket(formData: {name: string, email: string
     }
 
     try {
-        await adminDb.collection('supportTickets').add(ticketData);
+        await apiCall(`${API_ENDPOINTS.guarantees}/support`, {
+            method: 'POST',
+            body: JSON.stringify(ticketData),
+        });
         return { success: true, message: 'Support ticket submitted successfully!' };
     } catch (error) {
-        console.error('Error submitting support ticket:', error);
+        console.error('Error submitting support ticket via API:', error);
         return { success: false, message: 'Failed to submit your support ticket. Please try again later.' };
     }
 }


### PR DESCRIPTION
## Summary
- document that Supabase is the source of truth
- clarify database usage in backend and frontend docs
- switch frontend actions from Firestore to Supabase API calls

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c53b0fd4c8330b164cd8df427c16d