### PR TITLE
Add Firebase balance API and hook

### DIFF
--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -3,7 +3,7 @@
 
 import { useState, useEffect } from 'react';
 import { KeyMetricsCard } from "@/components/dashboard/figma/key-metrics-card";
-import { MyBalanceCard } from "@/components/dashboard/figma/my-balance-card";
+import { BalanceDisplay } from "@/components/dashboard/BalanceDisplay";
 import { RecentActivityTable } from "@/components/dashboard/figma/recent-activity-table";
 import { FigmaPortfolioPerformanceChart } from "@/components/dashboard/figma/figma-portfolio-performance-chart";
 import { PortfolioAllocationCard } from "@/components/dashboard/figma/portfolio-allocation-card";
@@ -114,7 +114,7 @@ export default function DashboardPage() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <PortfolioAllocationCard data={mockPortfolioAllocation} />
         <KeyMetricsCard metrics={dynamicKeyMetrics} />
-        <MyBalanceCard />
+        <BalanceDisplay userId={authUser?.uid} />
       </div>
 
       <TopCryptocurrencyTable cryptocurrencies={mockTopCryptocurrencies} />

--- a/frontend/src/components/dashboard/BalanceDisplay.tsx
+++ b/frontend/src/components/dashboard/BalanceDisplay.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useBalance } from '@/hooks/useBalance';
+import { useToast } from '@/hooks/use-toast';
+import { cn } from '@/lib/utils';
+
+interface BalanceDisplayProps {
+  userId?: string;
+  className?: string;
+}
+
+export function BalanceDisplay({ userId, className }: BalanceDisplayProps) {
+  const { balance, loading, error } = useBalance(userId);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (error) {
+      toast({ title: 'Error', description: error, variant: 'destructive' });
+    }
+  }, [error, toast]);
+
+  return (
+    <Card className={cn(className)}>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium uppercase text-muted-foreground">
+          Balance
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="text-center">
+        {loading ? (
+          <Skeleton className="h-8 w-32 mx-auto" />
+        ) : (
+          <p className="text-4xl font-bold text-foreground">
+            {balance
+              ? `$${balance.amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+              : '$0'}
+            <span className="text-lg ml-1 text-muted-foreground">{balance?.currency}</span>
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/hooks/useBalance.ts
+++ b/frontend/src/hooks/useBalance.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { fetchBalance, type Balance } from '@/lib/api/balance';
+
+export function useBalance(userId?: string) {
+  const [balance, setBalance] = useState<Balance | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!userId) {
+      setLoading(false);
+      setBalance(null);
+      return;
+    }
+
+    setLoading(true);
+    fetchBalance(userId)
+      .then((data) => {
+        setBalance(data);
+        setError(null);
+      })
+      .catch((err) => {
+        console.error('Failed to load balance', err);
+        setError('Failed to load balance');
+        setBalance(null);
+      })
+      .finally(() => setLoading(false));
+  }, [userId]);
+
+  return { balance, loading, error };
+}

--- a/frontend/src/lib/api/balance.ts
+++ b/frontend/src/lib/api/balance.ts
@@ -1,0 +1,13 @@
+export interface Balance {
+  amount: number;
+  currency: string;
+}
+
+export async function fetchBalance(userId: string): Promise<Balance> {
+  const res = await fetch(`/api/balance/${userId}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch balance');
+  }
+  const data = await res.json();
+  return data.balance as Balance;
+}

--- a/frontend/src/pages/api/balance/[userId].ts
+++ b/frontend/src/pages/api/balance/[userId].ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getAdminDb } from '@/lib/firebaseAdmin';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { userId } = req.query;
+
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  if (typeof userId !== 'string') {
+    return res.status(400).json({ error: 'Invalid user id' });
+  }
+
+  try {
+    const db = getAdminDb();
+    const doc = await db.collection('users').doc(userId).get();
+    if (!doc.exists) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    const data = doc.data();
+    const balance = data?.balance || { amount: 0, currency: 'USD' };
+    return res.status(200).json({ balance });
+  } catch (error) {
+    console.error('Error fetching balance:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}


### PR DESCRIPTION
## Summary
- create API route `pages/api/balance/[userId]` using Firebase Admin
- add client helper `lib/api/balance.ts`
- implement `useBalance` hook
- create `BalanceDisplay` component with skeleton and toast
- show user's balance on dashboard page

## Testing
- `npm run lint` *(fails: asks to configure ESLint)*
- `npm run typecheck` *(fails: type errors in unrelated files)*
- `npm run lint:backend` *(fails: flake8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c55687c3c8330839c8e219a523280