### PR TITLE
Switch frontend to backend API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,20 @@ solcraft-poker/
   - Integrazione wallet Solana
   - Sistema di autenticazione
 
-### Backend (`/backend`)
+-### Backend (`/backend`)
 - **Framework**: Python con FastAPI
-- **Database**: PostgreSQL/MongoDB
+- **Database**: PostgreSQL su Supabase (database autorevole della piattaforma)
 - **Funzionalità**:
   - API REST per frontend
   - Gestione utenti e autenticazione
   - Logica business tornei
   - Integrazione blockchain
+
+### Database Autorevole
+
+L'intera applicazione utilizza Supabase come sorgente principale dei dati. Tutti gli
+endpoint REST esposti dal backend accedono a Supabase e il frontend comunica con il
+backend per leggere e scrivere dati.
 
 ## Quick Start
 

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -22,9 +22,9 @@ import {
 } from "@/lib/mock-data";
 import { TournamentCard } from "@/components/tournaments/tournament-card";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { auth, db } from '@/lib/firebase';
+import { auth } from '@/lib/firebase';
 import { onAuthStateChanged, type User as FirebaseUser } from 'firebase/auth';
-import { doc, getDoc } from 'firebase/firestore';
+import { api } from '@/lib/api-config';
 import type { UserProfile, Investment, KeyMetric, Tournament } from '@/lib/types';
 import { Loader2, Activity, Award, TrendingUp, Crown, Landmark } from 'lucide-react';
 
@@ -41,10 +41,8 @@ export default function DashboardPage() {
       if (currentUser) {
         setAuthUser(currentUser);
         try {
-          const userDocRef = doc(db, "users", currentUser.uid);
-          const userDocSnap = await getDoc(userDocRef);
-          if (userDocSnap.exists()) {
-            const profileData = userDocSnap.data() as UserProfile;
+          const profileData = await api.getPlayerProfile(currentUser.uid) as UserProfile;
+          if (profileData) {
             setUserProfile(profileData);
 
             const activeInvestmentsCount = mockInvestments.filter(

--- a/frontend/src/components/dashboard/figma/my-balance-card.tsx
+++ b/frontend/src/components/dashboard/figma/my-balance-card.tsx
@@ -6,9 +6,9 @@ import { Button } from "@/components/ui/button";
 import { Copy, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
-import { auth, db } from "@/lib/firebase";
-import { onAuthStateChanged, type User as FirebaseUser } from "firebase/auth";
-import { doc, getDoc } from "firebase/firestore";
+import { auth } from "@/lib/firebase";
+import { onAuthStateChanged } from "firebase/auth";
+import { api } from "@/lib/api-config";
 import type { UserProfile } from "@/lib/types";
 
 interface MyBalanceCardProps {
@@ -30,23 +30,20 @@ export function MyBalanceCard({ className }: MyBalanceCardProps) {
       if (currentUser) {
         // setAuthUser(currentUser); // Not strictly needed if only using uid from currentUser
         try {
-          const userDocRef = doc(db, "users", currentUser.uid);
-          const userDocSnap = await getDoc(userDocRef);
-          if (userDocSnap.exists()) {
-            const profileData = userDocSnap.data() as UserProfile;
+          const profileData = await api.getPlayerProfile(currentUser.uid) as UserProfile;
+          if (profileData) {
             setDisplayBalance({
               amount: profileData.balance?.amount ?? 0,
               currency: profileData.balance?.currency ?? 'USD',
-              walletAddress: profileData.walletAddress ?? 'Not Connected' // More descriptive default
+              walletAddress: profileData.walletAddress ?? 'Not Connected'
             });
           } else {
-            // This case should ideally not happen if profile is created on signup
             toast({ title: "Profile not found", description: "Could not load balance details. Please complete your profile.", variant: "destructive" });
-             setDisplayBalance({ amount: 0, currency: 'USD', walletAddress: 'Not found' });
+            setDisplayBalance({ amount: 0, currency: 'USD', walletAddress: 'Not found' });
           }
         } catch (error) {
-          console.error("Error fetching user balance:", error);
-          toast({ title: "Error", description: "Could not load balance.", variant: "destructive" });
+          console.error('Error fetching user balance:', error);
+          toast({ title: 'Error', description: 'Could not load balance.', variant: 'destructive' });
           setDisplayBalance({ amount: 0, currency: 'USD', walletAddress: 'Error loading' });
         }
       } else {

--- a/frontend/src/lib/actions/investment.actions.ts
+++ b/frontend/src/lib/actions/investment.actions.ts
@@ -1,71 +1,42 @@
 
 'use server';
 
-import { getAdminDb } from '@/lib/firebaseAdmin';
-import { FieldValue } from 'firebase-admin/firestore';
-import { revalidatePath } from 'next/cache';
-import type { Investment } from '../types';
+import { api } from '@/lib/api-config';
 
-export async function makeInvestment(userId: string, details: { tournamentId: string, tournamentName: string, tierName: string, amount: number, tokenAmount: number }) {
-  const adminDb = getAdminDb();
-  if (!userId || !details || !details.tournamentId || details.amount <= 0) {
+interface InvestmentResponse {
+  status: string;
+  message: string;
+  data?: any;
+}
+
+export async function makeInvestment(
+  userId: string,
+  details: {
+    tournamentId: string;
+    tournamentName?: string;
+    tierName?: string;
+    amount: number;
+    tokenAmount?: number;
+  }
+) {
+  if (!userId || !details?.tournamentId || details.amount <= 0) {
     return { success: false, message: 'Invalid investment data provided.' };
   }
 
-  const investmentData: Omit<Investment, 'id'> = {
-    investorId: userId,
-    tournamentId: details.tournamentId,
-    tournamentName: details.tournamentName,
-    tierName: details.tierName,
-    investmentValueUSD: details.amount,
-    tokenAmount: details.tokenAmount,
-    investmentDate: new Date().toISOString(),
-    status: 'Active',
-  };
-
   try {
-    const userRef = adminDb.collection('users').doc(userId);
-    const investmentRef = adminDb.collection('investments').doc(); // Auto-generate ID
+    const result = await api.createInvestment({
+      user_id: userId,
+      tournament_id: details.tournamentId,
+      amount: details.amount,
+    }) as InvestmentResponse;
 
-    // Note: The 'tournaments' collection is conceptual and based on mock data.
-    // In a real app, this would update a live document. This may not find a doc
-    // if one doesn't exist in your actual Firestore DB. We will proceed assuming it might.
-    const tournamentRef = adminDb.collection('tournaments').doc(details.tournamentId);
+    if (result.status === 'success') {
+      return { success: true, message: 'Investment was successful!' };
+    }
 
-    // Using a transaction to ensure all writes succeed or none do.
-    await adminDb.runTransaction(async (transaction) => {
-        // 1. Create the new investment document
-        transaction.set(investmentRef, investmentData);
-        
-        // 2. Update user's total invested amount
-        transaction.update(userRef, {
-            totalInvested: FieldValue.increment(details.amount)
-        });
-
-        // 3. Update the tournament's raised amount
-        // This part is likely to fail if the tournament doc doesn't exist in Firestore.
-        // For robustness, we check its existence first, but this is a common issue with mock-first dev.
-        const tournamentDoc = await transaction.get(tournamentRef);
-        if (tournamentDoc.exists) {
-            transaction.update(tournamentRef, {
-                raisedAmount: FieldValue.increment(details.amount)
-            });
-        }
-    });
-
-    // Revalidate paths to reflect updated data
-    revalidatePath(`/tournaments/${details.tournamentId}`);
-    revalidatePath('/profile');
-    revalidatePath('/dashboard');
-
-    return { success: true, message: 'Investment was successful!' };
+    return { success: false, message: result.message };
   } catch (error) {
     console.error('Error making investment:', error);
-    // Check if the error is because the tournament doc doesn't exist.
-    // This is a common issue when working with mock data that might not be in the DB.
-    if ((error as any).code === 5) { // Firestore's NOT_FOUND error code
-         return { success: false, message: 'Your investment could not be processed because the tournament record was not found in the database.' };
-    }
-    return { success: false, message: 'Your investment could not be processed due to a server error.' };
+    return { success: false, message: 'Failed to create investment.' };
   }
 }

--- a/frontend/src/lib/actions/social.actions.ts
+++ b/frontend/src/lib/actions/social.actions.ts
@@ -1,71 +1,33 @@
 
 'use server';
 
-import { getAdminDb } from '@/lib/firebaseAdmin';
 import type { SocialPlayer } from '../types';
-import { FieldValue } from 'firebase-admin/firestore';
-import { revalidatePath } from 'next/cache';
+import { api } from '@/lib/api-config';
 
 export async function getPlayers(): Promise<SocialPlayer[]> {
-  const adminDb = getAdminDb();
   try {
-    const usersSnapshot = await adminDb.collection('users')
-      .orderBy('ranking')
-      .limit(50)
-      .get();
-      
-    if (usersSnapshot.empty) {
-      return [];
-    }
-
-    const players = usersSnapshot.docs.map(doc => {
-      const data = doc.data();
-      return {
-        ...data,
-        id: doc.id,
-        uid: doc.id,
-        // isFollowed is a client-side concern, determined by the logged-in user
-      } as SocialPlayer;
-    });
-    
-    return players;
+    const data = await api.getPlayers();
+    return data as SocialPlayer[];
   } catch (error) {
-    console.error("Error fetching players from Firestore:", error);
+    console.error('Error fetching players from API:', error);
     return [];
   }
 }
 
-export async function toggleFollow(currentUserId: string, targetUserId: string, isCurrentlyFollowing: boolean) {
-    const adminDb = getAdminDb();
-    if (!currentUserId || !targetUserId || currentUserId === targetUserId) {
-        return { success: false, message: 'Invalid request.' };
-    }
-    
-    const currentUserRef = adminDb.collection('users').doc(currentUserId);
-    const targetUserRef = adminDb.collection('users').doc(targetUserId);
+export async function toggleFollow(
+  currentUserId: string,
+  targetUserId: string,
+  isCurrentlyFollowing: boolean
+) {
+  if (!currentUserId || !targetUserId || currentUserId === targetUserId) {
+    return { success: false, message: 'Invalid request.' };
+  }
 
-    const batch = adminDb.batch();
-
-    if (isCurrentlyFollowing) {
-        // Unfollow action
-        batch.update(currentUserRef, { followingCount: FieldValue.increment(-1) });
-        batch.update(targetUserRef, { followersCount: FieldValue.increment(-1) });
-    } else {
-        // Follow action
-        batch.update(currentUserRef, { followingCount: FieldValue.increment(1) });
-        batch.update(targetUserRef, { followersCount: FieldValue.increment(1) });
-    }
-
-    try {
-        await batch.commit();
-        // Revalidate paths to reflect updated data for both users
-        revalidatePath('/social');
-        revalidatePath(`/profile/${targetUserId}`); // Assuming profile page uses ID
-        revalidatePath('/profile'); // Revalidate current user's profile page
-        
-        return { success: true, message: isCurrentlyFollowing ? 'Unfollowed successfully' : 'Followed successfully' };
-    } catch (error) {
-        console.error('Error toggling follow:', error);
-        return { success: false, message: 'Could not complete the action. Please try again.' };
-    }
+  try {
+    const data = await api.toggleFollow(targetUserId);
+    return { success: true, message: isCurrentlyFollowing ? 'Unfollowed successfully' : 'Followed successfully', data };
+  } catch (error) {
+    console.error('Error toggling follow:', error);
+    return { success: false, message: 'Could not complete the action. Please try again.' };
+  }
 }

--- a/frontend/src/lib/actions/support.actions.ts
+++ b/frontend/src/lib/actions/support.actions.ts
@@ -1,28 +1,30 @@
 
 'use server';
-import { getAdminDb } from '@/lib/firebaseAdmin';
+import { api } from '@/lib/api-config';
 import type { SupportTicket } from '../types';
 
-export async function submitSupportTicket(formData: {name: string, email: string, subject: string, message: string}, userId?: string) {
-    const adminDb = getAdminDb();
-    const ticketData: SupportTicket = {
-        name: formData.name,
-        email: formData.email,
-        subject: formData.subject,
-        message: formData.message,
-        createdAt: new Date().toISOString(),
-        status: 'open',
-    };
+export async function submitSupportTicket(
+  formData: { name: string; email: string; subject: string; message: string },
+  userId?: string
+) {
+  const ticketData: SupportTicket = {
+    name: formData.name,
+    email: formData.email,
+    subject: formData.subject,
+    message: formData.message,
+    createdAt: new Date().toISOString(),
+    status: 'open',
+  };
 
-    if (userId) {
-        ticketData.userId = userId;
-    }
+  if (userId) {
+    ticketData.userId = userId;
+  }
 
-    try {
-        await adminDb.collection('supportTickets').add(ticketData);
-        return { success: true, message: 'Support ticket submitted successfully!' };
-    } catch (error) {
-        console.error('Error submitting support ticket:', error);
-        return { success: false, message: 'Failed to submit your support ticket. Please try again later.' };
-    }
+  try {
+    await api.submitSupportTicket(ticketData);
+    return { success: true, message: 'Support ticket submitted successfully!' };
+  } catch (error) {
+    console.error('Error submitting support ticket:', error);
+    return { success: false, message: 'Failed to submit your support ticket. Please try again later.' };
+  }
 }

--- a/frontend/src/lib/actions/user.actions.ts
+++ b/frontend/src/lib/actions/user.actions.ts
@@ -1,24 +1,16 @@
 
 'use server';
 
-import { getAdminDb } from '@/lib/firebaseAdmin';
-import { revalidatePath } from 'next/cache';
+import { api } from '@/lib/api-config';
 import type { UserProfile } from '../types';
 
 export async function getUserProfile(userId: string): Promise<UserProfile | null> {
-  const adminDb = getAdminDb();
   if (!userId) return null;
   try {
-    const userDoc = await adminDb.collection('users').doc(userId).get();
-    if (!userDoc.exists) {
-      console.log(`No user profile found for UID: ${userId}`);
-      return null;
-    }
-    const data = userDoc.data() as UserProfile;
-    // Ensure id is part of the returned object
-    return { ...data, id: userDoc.id, uid: userDoc.id };
+    const data = await api.getPlayerProfile(userId);
+    return data as UserProfile;
   } catch (error) {
-    console.error("Error fetching user profile from Firestore:", error);
+    console.error('Error fetching user profile from API:', error);
     return null;
   }
 }
@@ -30,24 +22,14 @@ interface UserProfileUpdateData {
 }
 
 export async function updateProfile(userId: string, data: UserProfileUpdateData) {
-  const adminDb = getAdminDb();
   if (!userId) {
     return { success: false, message: 'User not authenticated.' };
   }
   try {
-    const userDocRef = adminDb.collection('users').doc(userId);
-    await userDocRef.update({
-      name: data.name,
-      username: data.username,
-      bio: data.bio,
-    });
-
-    revalidatePath('/settings');
-    revalidatePath('/profile');
-
+    await api.updatePlayerProfile(userId, data);
     return { success: true, message: 'Profile updated successfully.' };
   } catch (error) {
-    console.error("Error updating profile in Firestore:", error);
+    console.error('Error updating profile:', error);
     return { success: false, message: 'Failed to update profile.' };
   }
 }
@@ -60,17 +42,14 @@ interface NotificationSettings {
 }
 
 export async function updateNotificationSettings(userId: string, settings: NotificationSettings) {
-    const adminDb = getAdminDb();
-    if (!userId) {
-        return { success: false, message: 'User not authenticated.' };
-    }
-    try {
-        const userDocRef = adminDb.collection('users').doc(userId);
-        await userDocRef.update({ notificationSettings: settings });
-        revalidatePath('/settings');
-        return { success: true, message: 'Notification settings updated successfully.' };
-    } catch (error) {
-        console.error("Error updating notification settings:", error);
-        return { success: false, message: 'Failed to update settings.' };
-    }
+  if (!userId) {
+    return { success: false, message: 'User not authenticated.' };
+  }
+  try {
+    await api.updatePlayerProfile(userId, { notificationSettings: settings });
+    return { success: true, message: 'Notification settings updated successfully.' };
+  } catch (error) {
+    console.error('Error updating notification settings:', error);
+    return { success: false, message: 'Failed to update settings.' };
+  }
 }

--- a/frontend/src/lib/api-config.ts
+++ b/frontend/src/lib/api-config.ts
@@ -14,12 +14,20 @@ export const API_ENDPOINTS = {
   // Players
   players: `${API_BASE_URL}/api/players`,
   playerProfile: (id: string) => `${API_BASE_URL}/api/players/${id}`,
+  updatePlayerProfile: (id: string) => `${API_BASE_URL}/api/players/${id}`,
+  playerFollow: (id: string) => `${API_BASE_URL}/api/players/${id}/follow`,
   
   // Fees
   fees: `${API_BASE_URL}/api/fees`,
   
   // Guarantees
   guarantees: `${API_BASE_URL}/api/guarantees`,
+
+  // Investments
+  investments: `${API_BASE_URL}/api/investments`,
+
+  // Support
+  supportTickets: `${API_BASE_URL}/api/support`,
 } as const;
 
 // API Client configuration
@@ -78,6 +86,26 @@ export const api = {
   // Players
   getPlayers: () => apiCall<any[]>(API_ENDPOINTS.players),
   getPlayerProfile: (id: string) => apiCall<any>(API_ENDPOINTS.playerProfile(id)),
+  updatePlayerProfile: (id: string, data: any) =>
+    apiCall<any>(API_ENDPOINTS.updatePlayerProfile(id), {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+  toggleFollow: (id: string) =>
+    apiCall<any>(API_ENDPOINTS.playerFollow(id), { method: 'POST' }),
+
+  // Investments
+  createInvestment: (data: any) =>
+    apiCall<any>(API_ENDPOINTS.investments, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+
+  submitSupportTicket: (data: any) =>
+    apiCall<any>(API_ENDPOINTS.supportTickets, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
   
   // Fees
   getFees: () => apiCall<any[]>(API_ENDPOINTS.fees),


### PR DESCRIPTION
## Summary
- declare Supabase as the main database in the README
- expose additional endpoints in the frontend API helper
- drop Firebase Admin usage from server actions
- call backend API for user data in dashboard components

## Testing
- `npm test` *(fails: Missing script "test" in frontend)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c55699ab0833082385ca5fb08c37d