### PR TITLE
Add basic frontend and backend tests

### DIFF
--- a/backend/tests/test_tournaments.py
+++ b/backend/tests/test_tournaments.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import types
+if "jwt" not in sys.modules:
+    sys.modules["jwt"] = types.ModuleType("jwt")
+from fastapi.testclient import TestClient
+
+# Provide stub supabase module before importing app
+if 'supabase' not in sys.modules:
+    dummy = types.ModuleType('supabase')
+    class DummyClient:
+        def table(self, *a, **kw):
+            return self
+        def select(self, *a, **kw):
+            return self
+        def limit(self, *a, **kw):
+            return self
+        def execute(self):
+            return types.SimpleNamespace(data=[], error=None)
+    def create_client(url, key):
+        return DummyClient()
+    dummy.create_client = create_client
+    dummy.Client = DummyClient
+    sys.modules['supabase'] = dummy
+
+os.environ.setdefault('SUPABASE_URL', 'http://localhost')
+os.environ.setdefault('SUPABASE_SERVICE_ROLE_KEY', 'dummy')
+
+from main import app
+from api.routers.tournaments import get_tournament_service
+
+class DummyService:
+    def get_tournaments(self, status=None, creator_id=None):
+        return []
+
+def override_service():
+    return DummyService()
+
+app.dependency_overrides[get_tournament_service] = override_service
+client = TestClient(app)
+
+
+def test_get_tournaments_returns_empty_list():
+    response = client.get('/api/tournaments')
+    assert response.status_code == 200
+    assert response.json() == []

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,11 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({ dir: './' });
+
+/** @type {import('jest').Config} */
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testEnvironment: 'jest-environment-jsdom',
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "sol-craft-app",
   "version": "0.1.0",
@@ -10,7 +9,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --project tsconfig.json --noEmit"
+    "typecheck": "tsc --project tsconfig.json --noEmit",
+    "test": "jest"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.8.0",
@@ -58,10 +58,15 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.4",
+    "@testing-library/react": "^14.1.2",
+    "@types/jest": "^29.5.7",
     "@types/node": "^20.19.1",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18",
     "genkit-cli": "^1.8.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"

--- a/frontend/src/components/shared/__tests__/page-header.test.tsx
+++ b/frontend/src/components/shared/__tests__/page-header.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import { PageHeader } from "../page-header";
+
+describe("PageHeader", () => {
+  it("renders title and description", () => {
+    render(<PageHeader title="Test" description="Desc" />);
+    expect(screen.getByRole("heading", { name: "Test" })).toBeInTheDocument();
+    expect(screen.getByText("Desc")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest in the frontend with React Testing Library
- provide a sample PageHeader test
- enable Pytest in the backend with a tournament endpoint test
- keep root `npm test` script running both suites

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c556e17ec8330981d5176ee57e9b6