### PR TITLE
Align Supabase env var

### DIFF
--- a/backend/api/config/database.py
+++ b/backend/api/config/database.py
@@ -12,14 +12,15 @@ logger = logging.getLogger(__name__)
 class DatabaseConfig:
     def __init__(self):
         self.supabase_url = os.getenv("SUPABASE_URL")
-        self.supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        # Use the same environment variable name used across the project
+        self.supabase_key = os.getenv("SUPABASE_KEY")
         self._client: Optional[Client] = None
         
         if not self.supabase_url:
             raise ValueError("SUPABASE_URL environment variable is required")
         
         if not self.supabase_key:
-            raise ValueError("SUPABASE_SERVICE_ROLE_KEY environment variable is required")
+            raise ValueError("SUPABASE_KEY environment variable is required")
     
     @property
     def client(self) -> Client:


### PR DESCRIPTION
## Summary
- use `SUPABASE_KEY` in database config so it matches index.py and docs

## Testing
- `npm run test:backend`
- `npm run lint:backend` *(fails: multiple flake8 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686cd928bcac8330a86fe661596e1eae