### PR TITLE
Fix docs for environment and deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ cd backend && pip install -r requirements.txt && cd ..
 
 3. **Configurazione ambiente**
 ```bash
-# Copia e configura variabili d'ambiente
-cp frontend/.env.example frontend/.env.local
-cp backend/.env.example backend/.env
+# Crea i file per le variabili d'ambiente (nel repository non sono presenti `.env.example`)
+touch frontend/.env.local
+touch backend/.env
+# Popola i file con le configurazioni necessarie
 ```
 
 4. **Avvia i servizi**

--- a/SETUP_INSTRUCTIONS.md
+++ b/SETUP_INSTRUCTIONS.md
@@ -99,8 +99,8 @@ npm run dev:backend   # http://localhost:8000
 ## 🔧 Configurazione Deployment
 
 ### Frontend (Vercel)
-- Il frontend è già configurato per Vercel
-- File `vercel.json` presente in `/frontend`
+- Il frontend è già predisposto per il deploy su Vercel
+- Crea un file `vercel.json` in `/frontend` se desideri personalizzare la configurazione
 - Collega il repository GitHub a Vercel
 
 ### Backend (Railway/Heroku)

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,13 +2,13 @@
 
 Backend per la piattaforma di tokenizzazione SolCraft L2 su blockchain Solana.
 
-## Configurazione Deploy con GitHub Actions
+## Configurazione Deploy su Vercel
 
-Questo repository è configurato per il deploy automatico su Vercel tramite GitHub Actions. Il workflow è definito nel file `.github/workflows/vercel-deploy.yml`.
+Il backend può essere pubblicato su Vercel utilizzando la CLI o configurando un workflow personalizzato nel tuo repository.
 
 ### Prerequisiti
 
-Per utilizzare il workflow di deploy automatico, è necessario configurare i seguenti segreti nel repository GitHub:
+Per il deploy è necessario configurare i seguenti segreti nel repository GitHub o nell'interfaccia di Vercel:
 
 - `VERCEL_TOKEN`: Token di accesso per l'API Vercel
 - `VERCEL_ORG_ID`: ID dell'organizzazione Vercel
@@ -27,7 +27,7 @@ Per utilizzare il workflow di deploy automatico, è necessario configurare i seg
 
 1. **VERCEL_TOKEN**:
    - Vai su https://vercel.com/account/tokens
-   - Crea un nuovo token con nome "GitHub Actions"
+   - Crea un nuovo token (ad esempio "deploy")
    - Copia il token generato
 
 2. **VERCEL_ORG_ID e VERCEL_PROJECT_ID**:
@@ -46,9 +46,7 @@ Per utilizzare il workflow di deploy automatico, è necessario configurare i seg
 
 ### Trigger del Deploy
 
-Il deploy viene avviato automaticamente in due casi:
-- Push sul branch `main`
-- Avvio manuale del workflow tramite l'interfaccia di GitHub Actions
+Il deploy può essere avviato automaticamente con un push sul branch `main` se Vercel è collegato al repository, oppure manualmente dalla dashboard di Vercel.
 
 ## Connessione al Database
 


### PR DESCRIPTION
## Summary
- update frontend vercel config instructions
- clarify that env files must be created manually
- remove GitHub Actions references from backend docs

## Testing
- `npm test` *(fails: Missing script "test" in frontend)*

------
https://chatgpt.com/codex/tasks/task_e_686cd929a3bc8330948dd56fc681a302