### PR TITLE
Switch to psycopg2 DB helper

### DIFF
--- a/backend/api/config/__init__.py
+++ b/backend/api/config/__init__.py
@@ -1,7 +1,7 @@
 # api/config/__init__.py
 # Inizializzazione del package config
 
-from .database import get_supabase_client, db_config
+from .database import get_db_connection, db_config
 
-__all__ = ['get_supabase_client', 'db_config']
+__all__ = ['get_db_connection', 'db_config']
 

--- a/backend/api/services/player_profile_service.py
+++ b/backend/api/services/player_profile_service.py
@@ -6,11 +6,14 @@ from uuid import UUID
 import logging
 from datetime import datetime
 
+from ..config.database import get_db_connection
+
 logger = logging.getLogger(__name__)
 
 class PlayerProfileService:
-    def __init__(self, supabase):
-        self.supabase = supabase
+    def __init__(self, supabase=None):
+        """Service constructor. If no connection is provided a new one is created."""
+        self.supabase = supabase or get_db_connection()
 
     async def get_player_by_user_id(self, user_id: str):
         """Get a player profile by user ID."""

--- a/backend/api/services/tournament_service.py
+++ b/backend/api/services/tournament_service.py
@@ -5,14 +5,15 @@ from typing import List, Optional, Dict, Any
 from uuid import UUID
 import logging
 from datetime import datetime
-from ..config.database import get_supabase_client
+from ..config.database import get_db_connection
 from ..models.tournament_models import RANKING_CONFIG
 
 logger = logging.getLogger(__name__)
 
 class TournamentService:
     def __init__(self):
-        self.supabase = get_supabase_client()
+        # Use a generic PostgreSQL connection
+        self.supabase = get_db_connection()
 
     def create_tournament(
         self,


### PR DESCRIPTION
## Summary
- swap Supabase helper for a generic psycopg2 connection
- export `get_db_connection` instead of `get_supabase_client`
- adjust auth service and other callers to use the new helper
- allow `PlayerProfileService` to create its own connection

## Testing
- `python -m py_compile backend/api/utils/auth.py backend/api/config/database.py backend/api/config/__init__.py backend/api/services/tournament_service.py backend/api/services/player_profile_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce1262cf4833080ed5c45d89e8d23