### PR TITLE
Remove direct supabase setup from Flask API

### DIFF
--- a/backend/api/config/__init__.py
+++ b/backend/api/config/__init__.py
@@ -1,7 +1,7 @@
 # api/config/__init__.py
 # Inizializzazione del package config
 
-from .database import get_supabase_client, db_config
+from .database import get_supabase_client, db_config, get_db_connection
 
-__all__ = ['get_supabase_client', 'db_config']
+__all__ = ['get_supabase_client', 'db_config', 'get_db_connection']
 

--- a/backend/api/config/database.py
+++ b/backend/api/config/database.py
@@ -3,11 +3,22 @@
 Database configuration for SolCraft L2 backend.
 """
 import os
-from supabase import create_client, Client
-from typing import Optional
 import logging
+from typing import Optional
+import psycopg2
+from psycopg2.extras import register_uuid
+import traceback
+from supabase import create_client, Client
 
 logger = logging.getLogger(__name__)
+
+# PostgreSQL environment variables
+DATABASE_URL = os.getenv("DATABASE_URL")
+POSTGRES_URL = os.getenv("POSTGRES_URL")
+POSTGRES_URL_NON_POOLING = os.getenv("POSTGRES_URL_NON_POOLING")
+
+# Register UUID adapter for psycopg2
+register_uuid()
 
 class DatabaseConfig:
     def __init__(self):
@@ -50,4 +61,54 @@ db_config = DatabaseConfig()
 def get_supabase_client() -> Client:
     """Get the Supabase client instance."""
     return db_config.client
+
+
+def get_db_connection():
+    """Create a PostgreSQL connection using environment variables."""
+    logger.info("Tentativo di connessione al database PostgreSQL...")
+
+    try:
+        connection_string = None
+        connection_type = None
+
+        if POSTGRES_URL_NON_POOLING:
+            connection_string = POSTGRES_URL_NON_POOLING
+            connection_type = "POSTGRES_URL_NON_POOLING"
+        elif POSTGRES_URL:
+            connection_string = POSTGRES_URL
+            connection_type = "POSTGRES_URL"
+        elif DATABASE_URL:
+            connection_string = DATABASE_URL
+            connection_type = "DATABASE_URL"
+
+        if not connection_string:
+            logger.error("Nessuna stringa di connessione disponibile")
+            return None
+
+        if connection_string.startswith("postgresql://"):
+            connection_string = "postgres://" + connection_string[14:]
+
+        if "?" not in connection_string:
+            connection_string += "?sslmode=disable"
+        elif "sslmode=" not in connection_string:
+            connection_string += "&sslmode=disable"
+        else:
+            import re
+            connection_string = re.sub(r"sslmode=\w+", "sslmode=disable", connection_string)
+
+        logger.info(f"Tentativo di connessione con: {connection_type} - {connection_string[:20]}...")
+
+        conn = psycopg2.connect(
+            connection_string,
+            connect_timeout=60,
+            application_name="solcraft-backend",
+        )
+        conn.autocommit = True
+        logger.info("Connessione al database riuscita")
+        return conn
+    except Exception as e:
+        logger.error(f"Errore connessione al database: {str(e)}")
+        logger.error(traceback.format_exc())
+        return None
+
 


### PR DESCRIPTION
## Summary
- centralize PostgreSQL connection helper in `config/database.py`
- expose new helper through package init
- remove Supabase client setup from `api/index.py`
- use imported helper for DB tests and endpoints
- clean up env debug output

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ce12868f08330b76296ad0bb9f8fb