### PR TITLE
Update backend env vars

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -13,10 +13,9 @@ Per utilizzare il workflow di deploy automatico, è necessario configurare i seg
 - `VERCEL_TOKEN`: Token di accesso per l'API Vercel
 - `VERCEL_ORG_ID`: ID dell'organizzazione Vercel
 - `VERCEL_PROJECT_ID`: ID del progetto Vercel (prj_2Dh9UFSJ6Ul2DGxyJydFwQGAhLsu)
-- `POSTGRES_URL`: URL di connessione al database PostgreSQL su Supabase
-- `DATABASE_URL`: URL di connessione al database (stesso valore di POSTGRES_URL)
-- `SUPABASE_URL`: URL del progetto Supabase
-- `SUPABASE_KEY`: Chiave API di Supabase
+- `POSTGRES_URL`: URL di connessione al database PostgreSQL (pooler)
+- `POSTGRES_URL_NON_POOLING`: URL di connessione diretta al database (opzionale)
+- `DATABASE_URL`: URL di connessione al database (valore di fallback)
 - `JWT_SECRET`: Chiave segreta per la generazione dei token JWT
 - `SMTP_HOST`: Host del server SMTP per l'invio di email
 - `SMTP_PORT`: Porta del server SMTP
@@ -36,14 +35,6 @@ Per utilizzare il workflow di deploy automatico, è necessario configurare i seg
    - Esegui `vercel link` nella directory del progetto
    - I valori di ORG_ID e PROJECT_ID saranno salvati nel file `.vercel/project.json`
 
-### Come ottenere i segreti Supabase
-
-1. **SUPABASE_URL e SUPABASE_KEY**:
-   - Vai su https://app.supabase.io/
-   - Seleziona il tuo progetto
-   - Vai su Settings > API
-   - Copia "URL" e "anon/public key"
-
 ### Trigger del Deploy
 
 Il deploy viene avviato automaticamente in due casi:
@@ -52,7 +43,7 @@ Il deploy viene avviato automaticamente in due casi:
 
 ## Connessione al Database
 
-Il backend utilizza PostgreSQL su Supabase come database. La connessione è configurata tramite le variabili d'ambiente `POSTGRES_URL` e `DATABASE_URL`.
+Il backend utilizza un database PostgreSQL. La connessione è configurata tramite le variabili d'ambiente `POSTGRES_URL`, `POSTGRES_URL_NON_POOLING` e `DATABASE_URL`.
 
 ## Struttura del Progetto
 
@@ -67,10 +58,9 @@ Il backend utilizza PostgreSQL su Supabase come database. La connessione è conf
 2. Installa le dipendenze: `npm install`
 3. Crea un file `.env` con le variabili d'ambiente necessarie:
    ```
-   DATABASE_URL=postgresql://postgres:postgres@db.solcraftl2.supabase.co:5432/postgres
-   POSTGRES_URL=postgresql://postgres:postgres@db.solcraftl2.supabase.co:5432/postgres
-   SUPABASE_URL=https://db.solcraftl2.supabase.co
-   SUPABASE_KEY=your-supabase-key
+   DATABASE_URL=postgresql://username:password@host:5432/dbname
+   POSTGRES_URL=postgresql://username:password@host:5432/dbname
+   POSTGRES_URL_NON_POOLING=postgresql://username:password@host:5432/dbname
    JWT_SECRET=your-jwt-secret
    SMTP_HOST=smtp.example.com
    SMTP_PORT=587

--- a/backend/test_deploy_completo.md
+++ b/backend/test_deploy_completo.md
@@ -5,6 +5,4 @@ Questo file è stato creato per testare la pipeline di deploy automatico con tut
 - VERCEL_PROJECT_ID
 - DATABASE_URL
 - JWT_SECRET
-- SUPABASE_URL
-- SUPABASE_KEY
 Data: Sun Jun  8 09:45:24 EDT 2025

--- a/backend/test_deploy_segreti.md
+++ b/backend/test_deploy_segreti.md
@@ -2,7 +2,5 @@
 Questo file è stato creato per testare il deploy automatico dopo la configurazione dei segreti su Vercel con i nomi corretti in minuscolo:
 - postgres_url
 - database_url
-- supabase_url
-- supabase_key
 - jwt_secret
 Data: Sun Jun  8 10:33:55 EDT 2025


### PR DESCRIPTION
## Summary
- remove Supabase env vars from backend docs
- list only new PostgreSQL variables

## Testing
- `npm run test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce1292c1883309a474b226182cd2a