### PR TITLE
Replace Supabase config with PostgreSQL helper

### DIFF
--- a/backend/api/config/__init__.py
+++ b/backend/api/config/__init__.py
@@ -1,7 +1,7 @@
 # api/config/__init__.py
 # Inizializzazione del package config
 
-from .database import get_supabase_client, db_config
+from .database import get_db_connection, db_config
 
-__all__ = ['get_supabase_client', 'db_config']
+__all__ = ['get_db_connection', 'db_config']
 

--- a/backend/api/config/database.py
+++ b/backend/api/config/database.py
@@ -1,53 +1,70 @@
 # api/config/database.py
 """
 Database configuration for SolCraft L2 backend.
+
+This module now exposes a generic PostgreSQL connection helper using
+``psycopg2`` instead of the Supabase client that was previously used.
+The connection string is read from ``DATABASE_URL`` or ``POSTGRES_URL``
+environment variables.
 """
 import os
-from supabase import create_client, Client
-from typing import Optional
 import logging
+from typing import Optional
+
+import psycopg2
+from psycopg2.extensions import connection as PGConnection
 
 logger = logging.getLogger(__name__)
 
+
 class DatabaseConfig:
-    def __init__(self):
-        self.supabase_url = os.getenv("SUPABASE_URL")
-        self.supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-        self._client: Optional[Client] = None
-        
-        if not self.supabase_url:
-            raise ValueError("SUPABASE_URL environment variable is required")
-        
-        if not self.supabase_key:
-            raise ValueError("SUPABASE_SERVICE_ROLE_KEY environment variable is required")
-    
+    """Simple container for a reusable PostgreSQL connection."""
+
+    def __init__(self) -> None:
+        # Connection string priority: DATABASE_URL, POSTGRES_URL, POSTGRES_URL_NON_POOLING
+        self.database_url = (
+            os.getenv("DATABASE_URL")
+            or os.getenv("POSTGRES_URL")
+            or os.getenv("POSTGRES_URL_NON_POOLING")
+        )
+        if not self.database_url:
+            raise ValueError(
+                "DATABASE_URL or POSTGRES_URL environment variable is required"
+            )
+
+        self._connection: Optional[PGConnection] = None
+
     @property
-    def client(self) -> Client:
-        """Get Supabase client instance."""
-        if self._client is None:
+    def connection(self) -> PGConnection:
+        """Return a psycopg2 connection, initializing it if necessary."""
+        if self._connection is None or self._connection.closed != 0:
             try:
-                self._client = create_client(self.supabase_url, self.supabase_key)
-                logger.info("Supabase client initialized successfully")
+                self._connection = psycopg2.connect(self.database_url)
+                self._connection.autocommit = True
+                logger.info("PostgreSQL connection initialized successfully")
             except Exception as e:
-                logger.error(f"Failed to initialize Supabase client: {str(e)}")
+                logger.error(f"Failed to initialize PostgreSQL connection: {str(e)}")
                 raise
-        
-        return self._client
-    
+
+        return self._connection
+
     def test_connection(self) -> bool:
-        """Test database connection."""
+        """Test the database connection with a simple query."""
         try:
-            # Test connection with a simple query
-            response = self.client.table("tournaments").select("id").limit(1).execute()
+            with self.connection.cursor() as cur:
+                cur.execute("SELECT 1")
+                cur.fetchone()
             return True
         except Exception as e:
             logger.error(f"Database connection test failed: {str(e)}")
             return False
 
+
 # Global database instance
 db_config = DatabaseConfig()
 
-def get_supabase_client() -> Client:
-    """Get the Supabase client instance."""
-    return db_config.client
+
+def get_db_connection() -> PGConnection:
+    """Get the PostgreSQL connection instance."""
+    return db_config.connection
 

--- a/backend/api/services/tournament_service.py
+++ b/backend/api/services/tournament_service.py
@@ -5,14 +5,21 @@ from typing import List, Optional, Dict, Any
 from uuid import UUID
 import logging
 from datetime import datetime
-from ..config.database import get_supabase_client
+import os
+from supabase import create_client, Client
 from ..models.tournament_models import RANKING_CONFIG
 
 logger = logging.getLogger(__name__)
 
 class TournamentService:
     def __init__(self):
-        self.supabase = get_supabase_client()
+        """Initialise Supabase client using environment variables."""
+        supabase_url = os.getenv("SUPABASE_URL")
+        supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
+        if not supabase_url or not supabase_key:
+            raise ValueError("Supabase credentials are not configured")
+
+        self.supabase: Client = create_client(supabase_url, supabase_key)
 
     def create_tournament(
         self,

--- a/backend/api/utils/auth.py
+++ b/backend/api/utils/auth.py
@@ -6,14 +6,21 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from typing import Optional, Dict, Any
 import jwt
 import logging
-from ..config.database import get_supabase_client
+import os
+from supabase import create_client, Client
 
 logger = logging.getLogger(__name__)
 security = HTTPBearer()
 
 class AuthService:
     def __init__(self):
-        self.supabase = get_supabase_client()
+        """Initialise Supabase client using environment variables."""
+        supabase_url = os.getenv("SUPABASE_URL")
+        supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
+        if not supabase_url or not supabase_key:
+            raise ValueError("Supabase credentials are not configured")
+
+        self.supabase: Client = create_client(supabase_url, supabase_key)
     
     def verify_token(self, token: str) -> Optional[Dict[str, Any]]:
         """Verify JWT token and return user data."""


### PR DESCRIPTION
## Summary
- refactor database configuration to use psycopg2 instead of Supabase client
- update package exports
- instantiate Supabase client directly in services that need it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf5b78ccc8330941920698a631b59