### PR TITLE
Switch to API data fetching

### DIFF
--- a/backend/api/routers/players.py
+++ b/backend/api/routers/players.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, HTTPException, Depends, status
+import logging
+from ..services.player_profile_service import PlayerProfileService
+from ..config.database import get_supabase_client
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/players", tags=["players"])
+
+
+def get_player_service() -> PlayerProfileService:
+    return PlayerProfileService(get_supabase_client())
+
+
+@router.get("/")
+async def list_players(limit: int = 50, offset: int = 0, service: PlayerProfileService = Depends(get_player_service)):
+    """List player profiles."""
+    try:
+        players = await service.list_players(limit=limit, offset=offset)
+        return players
+    except Exception as e:
+        logger.error(f"Error listing players: {e}")
+        raise HTTPException(status_code=500, detail="Unable to list players")
+
+
+@router.get("/{user_id}")
+async def get_player_profile(user_id: str, service: PlayerProfileService = Depends(get_player_service)):
+    """Get a single player profile."""
+    try:
+        player = await service.get_player_profile_with_stats(user_id)
+        if not player:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Player not found")
+        return player
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error retrieving player {user_id}: {e}")
+        raise HTTPException(status_code=500, detail="Unable to retrieve player")

--- a/backend/api/services/player_profile_service.py
+++ b/backend/api/services/player_profile_service.py
@@ -162,3 +162,22 @@ class PlayerProfileService:
         except Exception as e:
             logger.error(f"Error in get_player_profile_with_stats: {str(e)}")
             raise
+
+    async def list_players(self, limit: int = 50, offset: int = 0):
+        """Retrieve a list of player profiles."""
+        try:
+            response = (
+                self.supabase
+                .table("players")
+                .select("*")
+                .range(offset, offset + limit - 1)
+                .execute()
+            )
+
+            if "error" in response:
+                raise Exception(f"Error listing players: {response['error']}")
+
+            return response["data"]
+        except Exception as e:
+            logger.error(f"Error in list_players: {str(e)}")
+            raise

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ load_dotenv()
 
 # Importa i router
 from api.routers.tournaments import router as tournaments_router
+from api.routers.players import router as players_router
 from api.config.database import db_config
 
 # Configurazione logging
@@ -42,6 +43,7 @@ app.add_middleware(
 
 # Registra i router
 app.include_router(tournaments_router, prefix="/api")
+app.include_router(players_router, prefix="/api")
 
 @app.get("/")
 async def root():

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -20,6 +20,7 @@ import {
   mockInvestments,
   mockPoolState 
 } from "@/lib/mock-data";
+import api from "@/lib/api-config";
 import { TournamentCard } from "@/components/tournaments/tournament-card";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { auth, db } from '@/lib/firebase';
@@ -33,10 +34,22 @@ export default function DashboardPage() {
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [dynamicKeyMetrics, setDynamicKeyMetrics] = useState<KeyMetric[]>(defaultMockKeyMetrics);
   const [isLoading, setIsLoading] = useState(true);
-
-  const featuredTournaments = mockTournaments.filter(t => t.status === 'Upcoming' || t.status === 'Live').slice(0, 3);
+  const [tournaments, setTournaments] = useState<Tournament[]>(mockTournaments);
+  const featuredTournaments = tournaments.filter(t => t.status === 'Upcoming' || t.status === 'Live').slice(0, 3);
 
   useEffect(() => {
+    const loadTournaments = async () => {
+      try {
+        const data = await api.getTournaments();
+        if (Array.isArray(data)) {
+          setTournaments(data as any);
+        }
+      } catch (err) {
+        console.error('Failed to fetch tournaments:', err);
+      }
+    };
+    loadTournaments();
+
     const unsubscribeAuth = onAuthStateChanged(auth, async (currentUser) => {
       if (currentUser) {
         setAuthUser(currentUser);

--- a/frontend/src/app/profile/[username]/page.tsx
+++ b/frontend/src/app/profile/[username]/page.tsx
@@ -1,20 +1,27 @@
 
 import { notFound } from "next/navigation";
 import { mockSocialPlayers, mockInvestments } from "@/lib/mock-data";
+import api from "@/lib/api-config";
 import { PublicProfileClient } from "@/components/profile/public-profile-client";
 
-// This function would typically fetch data from a DB or API
 async function getPlayerData(username: string) {
-  // Find the player in mock data
-  const player = mockSocialPlayers.find(
-    (p) => p.username.toLowerCase() === username.toLowerCase()
-  );
-  if (!player) {
-    return null;
+  try {
+    const players = await api.getPlayers();
+    const player = (Array.isArray(players) ? players : []).find(
+      (p: any) => p.username && p.username.toLowerCase() === username.toLowerCase()
+    );
+    if (!player) return null;
+    const investments = mockInvestments.filter(inv => inv.investorId === player.id);
+    return { player, investments };
+  } catch (err) {
+    console.error('Failed to fetch player profile', err);
+    const fallback = mockSocialPlayers.find(
+      (p) => p.username.toLowerCase() === username.toLowerCase()
+    );
+    if (!fallback) return null;
+    const investments = mockInvestments.filter(inv => inv.investorId === fallback.id);
+    return { player: fallback, investments };
   }
-  // Find investments for this player (mocking this)
-  const investments = mockInvestments.filter(inv => inv.investorId === player.id);
-  return { player, investments };
 }
 
 export default async function PublicProfilePage({ params }: { params: { username: string } }) {

--- a/frontend/src/app/tournaments/[id]/page.tsx
+++ b/frontend/src/app/tournaments/[id]/page.tsx
@@ -1,21 +1,29 @@
 
 import { notFound } from "next/navigation";
 import { mockTournaments } from "@/lib/mock-data";
-// import { TournamentDetailClient } from "@/components/tournaments/tournament-detail-client";
+import api from "@/lib/api-config";
+import { TournamentDetailClient } from "@/components/tournaments/tournament-detail-client";
 
-// This function would typically fetch data from a DB or API
+// Fetch tournament data from API with mock fallback
 async function getTournamentData(id: string) {
-  // Simulate API delay
-  await new Promise(resolve => setTimeout(resolve, 500)); 
-  const tournament = mockTournaments.find((t) => t.id === id);
-  return tournament;
+  try {
+    return await api.getTournament(id);
+  } catch (err) {
+    console.error('Failed to fetch tournament', err);
+    return mockTournaments.find((t) => t.id === id);
+  }
 }
 
 // Generate static paths for known tournaments at build time
 export async function generateStaticParams() {
-  return mockTournaments.map((tournament) => ({
-    id: tournament.id,
-  }));
+  try {
+    const tournaments = await api.getTournaments();
+    return Array.isArray(tournaments)
+      ? tournaments.map((t: any) => ({ id: t.id }))
+      : mockTournaments.map((t) => ({ id: t.id }));
+  } catch {
+    return mockTournaments.map((t) => ({ id: t.id }));
+  }
 }
 
 interface PageProps {
@@ -30,5 +38,5 @@ export default async function TournamentDetailPage({ params }: PageProps) {
     notFound();
   }
 
-  // return <TournamentDetailClient tournament={tournament} />;
+  return <TournamentDetailClient tournament={tournament} />;
 }

--- a/frontend/src/app/tournaments/page.tsx
+++ b/frontend/src/app/tournaments/page.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import Image from "next/image";
 import { PageHeader } from "@/components/shared/page-header";
 import { TournamentCard } from "@/components/tournaments/tournament-card";
 import { mockTournaments } from "@/lib/mock-data";
+import api from "@/lib/api-config";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
@@ -13,9 +14,24 @@ export default function TournamentsPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [buyInRange, setBuyInRange] = useState('any');
+  const [tournaments, setTournaments] = useState(mockTournaments);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await api.getTournaments();
+        if (Array.isArray(data)) {
+          setTournaments(data as any);
+        }
+      } catch (err) {
+        console.error('Failed to fetch tournaments:', err);
+      }
+    };
+    load();
+  }, []);
 
   const filteredTournaments = useMemo(() => {
-    return mockTournaments.filter(tournament => {
+    return tournaments.filter(tournament => {
       const searchMatch = searchTerm === '' || tournament.name.toLowerCase().includes(searchTerm.toLowerCase());
       const statusMatch = statusFilter === 'all' || tournament.status.toLowerCase() === statusFilter.toLowerCase();
       const buyInMatch = (() => {
@@ -34,7 +50,7 @@ export default function TournamentsPage() {
       })();
       return searchMatch && statusMatch && buyInMatch;
     });
-  }, [searchTerm, statusFilter, buyInRange]);
+  }, [tournaments, searchTerm, statusFilter, buyInRange]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- add players API router and update FastAPI app
- extend player service with list method
- fetch tournaments and profiles from API in frontend pages
- use API fallback logic on dashboard and social pages

## Testing
- `npm run test` *(fails: Missing script "test" in frontend)*
- `npm run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cfaf6956c8330a75796bb0dcd99f9