### PR TITLE
Add tournaments API fetching with mock fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ backend/build/
 .env.production.local
 frontend/.env*
 backend/.env*
+!frontend/.env.example
+!backend/.env.example
 
 # IDE
 .vscode/

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ cd backend && pip install -r requirements.txt && cd ..
 # Copia e configura variabili d'ambiente
 cp frontend/.env.example frontend/.env.local
 cp backend/.env.example backend/.env
+# Imposta l'URL dell'API backend e abilita eventuale fallback ai dati mock
+# in frontend/.env.local
+# NEXT_PUBLIC_API_URL=http://localhost:8000
+# NEXT_PUBLIC_USE_MOCK_DATA=true
 ```
 
 4. **Avvia i servizi**

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_USE_MOCK_DATA=true

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -97,6 +97,11 @@ NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
 NEXT_PUBLIC_FIREBASE_APP_ID=
 NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=
+
+# URL del backend FastAPI
+NEXT_PUBLIC_API_URL=http://localhost:8000
+# Usa dati mock se l'API non è raggiungibile
+NEXT_PUBLIC_USE_MOCK_DATA=true
 ```
 
 **Note:** Service account keys are highly sensitive and **must not be committed to version control.**
@@ -136,6 +141,8 @@ This project is optimized for deployment on Vercel.
     *   `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID`: Your Messaging Sender ID.
     *   `NEXT_PUBLIC_FIREBASE_APP_ID`: Your App ID.
     *   `NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID`: Your Measurement ID (optional).
+    *   `NEXT_PUBLIC_API_URL`: URL of your backend API (e.g. `http://localhost:8000`).
+    *   `NEXT_PUBLIC_USE_MOCK_DATA`: `true` to use built-in mock data when the API is unavailable.
 
 4.  **Deploy:** Trigger a deployment. Vercel will build and deploy your application.
 

--- a/frontend/src/app/tournaments/[id]/page.tsx
+++ b/frontend/src/app/tournaments/[id]/page.tsx
@@ -1,21 +1,43 @@
 
 import { notFound } from "next/navigation";
 import { mockTournaments } from "@/lib/mock-data";
-// import { TournamentDetailClient } from "@/components/tournaments/tournament-detail-client";
+import { TournamentDetailClient } from "@/components/tournaments/tournament-detail-client";
 
-// This function would typically fetch data from a DB or API
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+// Fetch tournament data from API with fallback to mock data
 async function getTournamentData(id: string) {
-  // Simulate API delay
-  await new Promise(resolve => setTimeout(resolve, 500)); 
-  const tournament = mockTournaments.find((t) => t.id === id);
-  return tournament;
+  const useMock = process.env.NEXT_PUBLIC_USE_MOCK_DATA === 'true';
+  if (useMock) {
+    return mockTournaments.find((t) => t.id === id);
+  }
+
+  try {
+    const res = await fetch(`${API_URL}/api/tournaments/${id}`, { cache: 'no-store' });
+    if (!res.ok) throw new Error('Failed to fetch');
+    return await res.json();
+  } catch (error) {
+    console.error('Error fetching tournament:', error);
+    return mockTournaments.find((t) => t.id === id);
+  }
 }
 
 // Generate static paths for known tournaments at build time
 export async function generateStaticParams() {
-  return mockTournaments.map((tournament) => ({
-    id: tournament.id,
-  }));
+  const useMock = process.env.NEXT_PUBLIC_USE_MOCK_DATA === 'true';
+  if (useMock) {
+    return mockTournaments.map((tournament) => ({ id: tournament.id }));
+  }
+
+  try {
+    const res = await fetch(`${API_URL}/api/tournaments`);
+    if (!res.ok) throw new Error('Failed to fetch');
+    const data = await res.json();
+    return data.map((t: any) => ({ id: String(t.id) }));
+  } catch (error) {
+    console.error('Error generating static params:', error);
+    return mockTournaments.map((tournament) => ({ id: tournament.id }));
+  }
 }
 
 interface PageProps {
@@ -30,5 +52,5 @@ export default async function TournamentDetailPage({ params }: PageProps) {
     notFound();
   }
 
-  // return <TournamentDetailClient tournament={tournament} />;
+  return <TournamentDetailClient tournament={tournament} />;
 }

--- a/frontend/src/app/tournaments/page.tsx
+++ b/frontend/src/app/tournaments/page.tsx
@@ -1,9 +1,11 @@
 "use client";
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import Image from "next/image";
 import { PageHeader } from "@/components/shared/page-header";
 import { TournamentCard } from "@/components/tournaments/tournament-card";
 import { mockTournaments } from "@/lib/mock-data";
+import { api } from "@/lib/api-config";
+import type { Tournament } from "@/lib/types";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
@@ -13,9 +15,26 @@ export default function TournamentsPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [buyInRange, setBuyInRange] = useState('any');
+  const [tournaments, setTournaments] = useState<Tournament[]>([]);
+
+  useEffect(() => {
+    const useMock = process.env.NEXT_PUBLIC_USE_MOCK_DATA === 'true';
+    if (useMock) {
+      setTournaments(mockTournaments);
+      return;
+    }
+    api.getTournaments()
+      .then((data) => {
+        setTournaments(data as Tournament[]);
+      })
+      .catch((err) => {
+        console.error('Failed to fetch tournaments:', err);
+        setTournaments(mockTournaments);
+      });
+  }, []);
 
   const filteredTournaments = useMemo(() => {
-    return mockTournaments.filter(tournament => {
+    return tournaments.filter(tournament => {
       const searchMatch = searchTerm === '' || tournament.name.toLowerCase().includes(searchTerm.toLowerCase());
       const statusMatch = statusFilter === 'all' || tournament.status.toLowerCase() === statusFilter.toLowerCase();
       const buyInMatch = (() => {


### PR DESCRIPTION
## Summary
- implement fetch logic in tournaments page and detail page
- load mock tournaments when API isn't accessible, controlled by `NEXT_PUBLIC_USE_MOCK_DATA`
- document new environment variables and example env file

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686cfb3f8df08330a757c1b6733bb746