### PR TITLE
Update build configuration

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -191,6 +191,9 @@ Firebase is used for backend services: Authentication, Firestore database, and S
 *   `npm run start`: Starts the Next.js production server.
 *   `npm run lint`: Lints the project.
 
+Builds will fail if there are TypeScript or ESLint errors. The Next.js
+configuration does not ignore these issues during `npm run build`.
+
 ## Contributing
 
 (Placeholder) Contributions are welcome!

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -3,10 +3,10 @@ import type {NextConfig} from 'next';
 const nextConfig: NextConfig = {
   /* config options here */
   typescript: {
-    ignoreBuildErrors: true, // Changed to false for production
+    ignoreBuildErrors: false, // Builds now fail on type errors
   },
   eslint: {
-    ignoreDuringBuilds: true, // Changed to false for production
+    ignoreDuringBuilds: false, // Builds now fail on lint errors
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
## Summary
- enforce strict type and lint checking during build
- mention build failures on lint/type errors in frontend docs

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cfb42ff8c833096ce7b4d8a8a2a3d