### PR TITLE
Add environment example files for setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ backend/build/
 .env.production.local
 frontend/.env*
 backend/.env*
+!frontend/.env.example
+!backend/.env.example
 
 # IDE
 .vscode/

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ cd backend && pip install -r requirements.txt && cd ..
 # Copia e configura variabili d'ambiente
 cp frontend/.env.example frontend/.env.local
 cp backend/.env.example backend/.env
+# Modifica i file appena copiati inserendo le tue chiavi e URL
 ```
 
 4. **Avvia i servizi**

--- a/SETUP_INSTRUCTIONS.md
+++ b/SETUP_INSTRUCTIONS.md
@@ -65,12 +65,14 @@ cd backend && pip install -r requirements.txt && cd ..
 
 ### 4. Configura le Variabili d'Ambiente
 
+Copia i file di esempio e personalizzali con le tue credenziali:
+
 ```bash
 # Frontend
 cp frontend/.env.example frontend/.env.local
 # Modifica frontend/.env.local con le tue configurazioni
 
-# Backend  
+# Backend
 cp backend/.env.example backend/.env
 # Modifica backend/.env con le tue configurazioni
 ```

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,22 @@
+# Example environment variables for SolCraft Poker backend
+
+# Database configuration
+DATABASE_URL=
+POSTGRES_URL=
+POSTGRES_URL_NON_POOLING=
+SUPABASE_URL=
+SUPABASE_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Security
+JWT_SECRET=
+
+# Email (SMTP) configuration
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+
+# Server
+HOST=0.0.0.0
+PORT=8000

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,17 @@
+# Example environment variables for SolCraft Poker frontend
+
+# --- Server-Side Firebase Admin Configuration ---
+GOOGLE_APPLICATION_CREDENTIALS=
+FIREBASE_PROJECT_ID=your-firebase-project-id
+
+# --- Client-Side Firebase Configuration ---
+NEXT_PUBLIC_FIREBASE_API_KEY=
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
+NEXT_PUBLIC_FIREBASE_APP_ID=
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=
+
+# --- API Configuration ---
+NEXT_PUBLIC_API_URL=http://localhost:8000


### PR DESCRIPTION
## Summary
- add `.env.example` templates for frontend and backend
- allow `.env.example` in version control via `.gitignore`
- update README and SETUP_INSTRUCTIONS with copy steps

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_686cfb455fa08330b3d3b49260660d01