### PR TITLE
Add environment variable templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ backend/build/
 .env.production.local
 frontend/.env*
 backend/.env*
+!frontend/.env.example
+!backend/.env.example
 
 # IDE
 .vscode/

--- a/README.md
+++ b/README.md
@@ -63,9 +63,12 @@ cd backend && pip install -r requirements.txt && cd ..
 
 3. **Configurazione ambiente**
 ```bash
-# Copia e configura variabili d'ambiente
+# Copia i file di esempio con le variabili d'ambiente
 cp frontend/.env.example frontend/.env.local
 cp backend/.env.example backend/.env
+# I template `.env.example` elencano tutte le variabili richieste
+# (es. `NEXT_PUBLIC_FIREBASE_API_KEY`, `SUPABASE_URL`).
+# Apri i file copiati e inserisci i tuoi valori.
 ```
 
 4. **Avvia i servizi**

--- a/SETUP_INSTRUCTIONS.md
+++ b/SETUP_INSTRUCTIONS.md
@@ -70,9 +70,11 @@ cd backend && pip install -r requirements.txt && cd ..
 cp frontend/.env.example frontend/.env.local
 # Modifica frontend/.env.local con le tue configurazioni
 
-# Backend  
+# Backend
 cp backend/.env.example backend/.env
 # Modifica backend/.env con le tue configurazioni
+# I file `.env.example` contengono tutte le variabili necessarie
+# riportate nei README (ad es. `NEXT_PUBLIC_FIREBASE_API_KEY`, `SUPABASE_URL`).
 ```
 
 ### 5. Testa il Setup

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,22 @@
+# Example environment variables for SolCraft Poker backend
+# Copy this file to .env and fill in your values
+
+# PostgreSQL / Supabase configuration
+DATABASE_URL=
+POSTGRES_URL=
+SUPABASE_URL=
+SUPABASE_KEY=
+
+# Authentication
+JWT_SECRET=
+
+# SMTP configuration
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+
+# Deployment / CI
+VERCEL_TOKEN=
+VERCEL_ORG_ID=
+VERCEL_PROJECT_ID=

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,18 @@
+# Example environment variables for SolCraft Poker frontend
+# Copy this file to .env.local and fill in your values
+
+# --- Server-Side Firebase Admin Configuration ---
+GOOGLE_APPLICATION_CREDENTIALS=
+FIREBASE_PROJECT_ID=
+
+# --- Client-Side Firebase Configuration ---
+NEXT_PUBLIC_FIREBASE_API_KEY=
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
+NEXT_PUBLIC_FIREBASE_APP_ID=
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=
+
+# Backend API
+NEXT_PUBLIC_API_URL=


### PR DESCRIPTION
## Summary
- provide `.env.example` templates for backend and frontend
- exclude these examples from gitignore rules
- document using the env files in README and setup guide

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: missing script)*


------
https://chatgpt.com/codex/tasks/task_e_686d13f902d483309eb22d3a1d3fc605