### PR TITLE
Unify Supabase key env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ backend/build/
 .env.production.local
 frontend/.env*
 backend/.env*
+!backend/.env.example
 
 # IDE
 .vscode/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,9 @@
+DATABASE_URL=postgresql://postgres:postgres@db.solcraftl2.supabase.co:5432/postgres
+POSTGRES_URL=postgresql://postgres:postgres@db.solcraftl2.supabase.co:5432/postgres
+SUPABASE_URL=https://db.solcraftl2.supabase.co
+SUPABASE_KEY=your-supabase-key
+JWT_SECRET=your-jwt-secret
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your-smtp-user
+SMTP_PASS=your-smtp-password

--- a/backend/README.md
+++ b/backend/README.md
@@ -65,7 +65,7 @@ Il backend utilizza PostgreSQL su Supabase come database. La connessione è conf
 
 1. Clona il repository
 2. Installa le dipendenze: `npm install`
-3. Crea un file `.env` con le variabili d'ambiente necessarie:
+3. Copia `backend/.env.example` in `.env` e personalizza le variabili d'ambiente:
    ```
    DATABASE_URL=postgresql://postgres:postgres@db.solcraftl2.supabase.co:5432/postgres
    POSTGRES_URL=postgresql://postgres:postgres@db.solcraftl2.supabase.co:5432/postgres

--- a/backend/api/config/database.py
+++ b/backend/api/config/database.py
@@ -12,14 +12,14 @@ logger = logging.getLogger(__name__)
 class DatabaseConfig:
     def __init__(self):
         self.supabase_url = os.getenv("SUPABASE_URL")
-        self.supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        self.supabase_key = os.getenv("SUPABASE_KEY")
         self._client: Optional[Client] = None
         
         if not self.supabase_url:
             raise ValueError("SUPABASE_URL environment variable is required")
         
         if not self.supabase_key:
-            raise ValueError("SUPABASE_SERVICE_ROLE_KEY environment variable is required")
+            raise ValueError("SUPABASE_KEY environment variable is required")
     
     @property
     def client(self) -> Client:


### PR DESCRIPTION
## Summary
- use `SUPABASE_KEY` consistently in backend
- add backend/.env.example with common vars
- update backend README to reference the example env file
- allow backend/.env.example in gitignore

## Testing
- `npm run test` *(fails: Missing script "test" in frontend)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d13fb63688330afd46b5edb5a3f82