### PR TITLE
Add minimal poker engine backend

### DIFF
--- a/backend/poker/README.md
+++ b/backend/poker/README.md
@@ -1,0 +1,34 @@
+# Poker Engine
+
+This directory contains a lightweight Texas Hold'em engine used by the backend.
+It is intentionally small and focuses only on card management and hand
+evaluation so that future API endpoints can interact with it.
+
+## Running the Engine
+
+The engine does not expose an HTTP API yet. It can be exercised from Python:
+
+```bash
+# install dependencies
+pip install -r requirements.txt
+
+# run a quick demo
+python - <<'PY'
+from poker.service import PokerService
+
+service = PokerService(["Alice", "Bob"])
+service.deal_hole_cards()
+service.deal_flop()
+service.deal_turn()
+service.deal_river()
+print(service.game_state())
+print(service.get_player_hand("Alice"))
+PY
+```
+
+## Extending
+
+- Add new methods in `PokerService` to handle betting, folding and other game
+  mechanics.
+- Extend `PokerGame` for multiple rounds or tournament logic.
+- Use these classes inside FastAPI routers to create API endpoints.

--- a/backend/poker/__init__.py
+++ b/backend/poker/__init__.py
@@ -1,0 +1,16 @@
+from .cards import Card, Deck, Suit, Rank
+from .game import PokerGame, Player
+from .service import PokerService
+from .hand_evaluator import evaluate, describe
+
+__all__ = [
+    "Card",
+    "Deck",
+    "Suit",
+    "Rank",
+    "PokerGame",
+    "Player",
+    "PokerService",
+    "evaluate",
+    "describe",
+]

--- a/backend/poker/cards.py
+++ b/backend/poker/cards.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+from enum import Enum
+import random
+
+class Suit(str, Enum):
+    CLUBS = "C"
+    DIAMONDS = "D"
+    HEARTS = "H"
+    SPADES = "S"
+
+class Rank(str, Enum):
+    TWO = "2"
+    THREE = "3"
+    FOUR = "4"
+    FIVE = "5"
+    SIX = "6"
+    SEVEN = "7"
+    EIGHT = "8"
+    NINE = "9"
+    TEN = "T"
+    JACK = "J"
+    QUEEN = "Q"
+    KING = "K"
+    ACE = "A"
+
+RANK_ORDER = {
+    Rank.TWO: 2,
+    Rank.THREE: 3,
+    Rank.FOUR: 4,
+    Rank.FIVE: 5,
+    Rank.SIX: 6,
+    Rank.SEVEN: 7,
+    Rank.EIGHT: 8,
+    Rank.NINE: 9,
+    Rank.TEN: 10,
+    Rank.JACK: 11,
+    Rank.QUEEN: 12,
+    Rank.KING: 13,
+    Rank.ACE: 14,
+}
+
+@dataclass(frozen=True)
+class Card:
+    rank: Rank
+    suit: Suit
+
+    def __str__(self) -> str:
+        return f"{self.rank.value}{self.suit.value}"
+
+
+def build_deck() -> list[Card]:
+    return [Card(rank, suit) for suit in Suit for rank in Rank]
+
+
+class Deck:
+    def __init__(self) -> None:
+        self.cards = build_deck()
+        self.shuffle()
+
+    def shuffle(self) -> None:
+        random.shuffle(self.cards)
+
+    def deal(self, n: int) -> list[Card]:
+        dealt = self.cards[:n]
+        self.cards = self.cards[n:]
+        return dealt

--- a/backend/poker/game.py
+++ b/backend/poker/game.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import List
+
+from .cards import Card, Deck
+from .hand_evaluator import evaluate, describe
+
+
+@dataclass
+class Player:
+    name: str
+    hole_cards: List[Card] = field(default_factory=list)
+
+
+@dataclass
+class PokerGame:
+    players: List[Player]
+    deck: Deck = field(default_factory=Deck)
+    community_cards: List[Card] = field(default_factory=list)
+
+    def deal_hole_cards(self) -> None:
+        for player in self.players:
+            player.hole_cards = self.deck.deal(2)
+
+    def deal_flop(self) -> None:
+        self.community_cards.extend(self.deck.deal(3))
+
+    def deal_turn(self) -> None:
+        self.community_cards.extend(self.deck.deal(1))
+
+    def deal_river(self) -> None:
+        self.community_cards.extend(self.deck.deal(1))
+
+    def player_best_score(self, player: Player) -> int:
+        cards = player.hole_cards + self.community_cards
+        if len(cards) < 7:
+            raise ValueError("Not enough cards to evaluate")
+        return evaluate(cards)
+
+    def player_best_hand_name(self, player: Player) -> str:
+        cards = player.hole_cards + self.community_cards
+        if len(cards) < 7:
+            raise ValueError("Not enough cards to evaluate")
+        return describe(cards)

--- a/backend/poker/hand_evaluator.py
+++ b/backend/poker/hand_evaluator.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from treys import Card as TCard, Evaluator
+from .cards import Card, Suit
+
+
+def card_to_int(card: Card) -> int:
+    # Map our Card to treys Card integer representation
+    rank_str = card.rank.value
+    suit_map = {
+        Suit.SPADES: "s",
+        Suit.HEARTS: "h",
+        Suit.DIAMONDS: "d",
+        Suit.CLUBS: "c",
+    }
+    suit_str = suit_map[card.suit]
+    treys_str = rank_str + suit_str
+    return TCard.new(treys_str)
+
+
+def evaluate(seven_cards: list[Card]) -> int:
+    """Return hand strength score; lower is better in treys."""
+    evaluator = Evaluator()
+    ints = [card_to_int(c) for c in seven_cards]
+    return evaluator.evaluate(ints[:2], ints[2:])
+
+
+def describe(seven_cards: list[Card]) -> str:
+    evaluator = Evaluator()
+    ints = [card_to_int(c) for c in seven_cards]
+    score = evaluator.evaluate(ints[:2], ints[2:])
+    return evaluator.class_to_string(evaluator.get_rank_class(score))

--- a/backend/poker/service.py
+++ b/backend/poker/service.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+from typing import List, Dict
+
+from .game import PokerGame, Player
+
+
+class PokerService:
+    """Simple facade to interact with the PokerGame engine."""
+
+    def __init__(self, player_names: List[str]) -> None:
+        players = [Player(name) for name in player_names]
+        self.game = PokerGame(players)
+
+    def deal_hole_cards(self) -> None:
+        self.game.deal_hole_cards()
+
+    def deal_flop(self) -> None:
+        self.game.deal_flop()
+
+    def deal_turn(self) -> None:
+        self.game.deal_turn()
+
+    def deal_river(self) -> None:
+        self.game.deal_river()
+
+    def get_player_hand(self, player_name: str) -> Dict[str, str]:
+        player = next(p for p in self.game.players if p.name == player_name)
+        hand_name = self.game.player_best_hand_name(player)
+        return {
+            "hand": hand_name,
+            "cards": [str(c) for c in player.hole_cards],
+        }
+
+    def game_state(self) -> Dict[str, List[str]]:
+        return {
+            "players": {p.name: [str(c) for c in p.hole_cards] for p in self.game.players},
+            "community": [str(c) for c in self.game.community_cards],
+        }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,7 @@ python-jose[cryptography]==3.3.0
 PyJWT==2.8.0
 
 # Utilities
+treys==0.1.8
 python-multipart==0.0.6
 pydantic==2.5.0
 python-dotenv==1.0.0

--- a/backend/tests/test_poker_engine.py
+++ b/backend/tests/test_poker_engine.py
@@ -1,0 +1,24 @@
+import pytest
+
+from poker.service import PokerService
+from poker.cards import Deck
+
+
+def test_deck_unique_cards():
+    deck = Deck()
+    dealt = deck.deal(52)
+    assert len(set(str(c) for c in dealt)) == 52
+
+
+def test_service_flow():
+    service = PokerService(["Alice", "Bob"])
+    service.deal_hole_cards()
+    service.deal_flop()
+    service.deal_turn()
+    service.deal_river()
+    state = service.game_state()
+    assert len(state["community"]) == 5
+    for cards in state["players"].values():
+        assert len(cards) == 2
+    hand_info = service.get_player_hand("Alice")
+    assert "hand" in hand_info


### PR DESCRIPTION
## Summary
- create `backend/poker` package with simple Texas Hold'em implementation using `treys`
- expose basic functionality through `PokerService`
- document how to run and extend the engine
- include tests for the new module

## Testing
- `cd backend && python -m pytest -q`
- `npm run test:backend`

------
https://chatgpt.com/codex/tasks/task_e_686d13ff2bf08330895d7d839e37994c