### PR TITLE
Add pytest-based backend tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ npm run dev:backend
 npm run dev
 ```
 
+### Test
+
+Per eseguire la suite di test backend con **pytest**:
+
+```bash
+npm run test:backend
+```
+
 ## Scripts Disponibili
 
 - `npm run dev` - Avvia frontend e backend in parallelo
@@ -87,6 +95,8 @@ npm run dev
 - `npm run dev:backend` - Avvia solo il backend
 - `npm run build` - Build di produzione per entrambi
 - `npm run test` - Esegue tutti i test
+- `npm run test:backend` - Esegue i test del backend (pytest)
+- `npm run test:frontend` - Esegue i test del frontend
 - `npm run lint` - Linting del codice
 
 ## Deployment

--- a/backend/tests/test_tournament_router.py
+++ b/backend/tests/test_tournament_router.py
@@ -1,0 +1,91 @@
+from fastapi.testclient import TestClient
+from uuid import uuid4
+import os
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ex.ex")
+from main import app
+from api.routers.tournaments import get_tournament_service
+from api.utils.auth import get_current_user
+
+
+def sample_tournament():
+    return {
+        "id": str(uuid4()),
+        "name": "Test",
+        "description": "desc",
+        "game_type": "Poker",
+        "target_pool_amount": 1000.0,
+        "tournament_buy_in": None,
+        "external_tournament_url": None,
+        "funding_end_time": None,
+        "creator_user_id": str(uuid4()),
+        "player_ranking_at_creation": "BRONZE",
+        "status": "funding_open",
+        "initial_platform_fee_pct": 0.1,
+        "initial_platform_fee_amount": 100.0,
+        "initial_platform_fee_paid": True,
+        "player_guarantee_pct": 0.2,
+        "player_guarantee_amount_required": 200.0,
+        "player_guarantee_paid": True,
+        "winnings_platform_fee_pct": 0.2,
+        "current_pool_amount": 0.0,
+        "total_winnings_from_tournament": None,
+        "platform_winnings_fee_amount": None,
+        "net_winnings_for_investors": None,
+        "created_at": "2023-01-01T00:00:00",
+        "updated_at": "2023-01-01T00:00:00",
+    }
+
+
+class DummyService:
+    def __init__(self, tournament):
+        self.tournament = tournament
+        self.called = None
+
+    def get_tournaments(self, status=None, creator_id=None):
+        assert status == "funding_open"
+        return [self.tournament]
+
+    def process_investment(self, tournament_id, user_id, amount):
+        self.called = (tournament_id, user_id, amount)
+        return self.tournament
+
+
+def override_user():
+    return {"id": "user1"}
+
+
+def test_get_open_tournaments():
+    t = sample_tournament()
+    service = DummyService(t)
+    app.dependency_overrides[get_tournament_service] = lambda: service
+    client = TestClient(app)
+    resp = client.get("/api/tournaments/open")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["id"] == t["id"]
+    app.dependency_overrides.clear()
+
+
+def test_invest_in_tournament_endpoint():
+    t = sample_tournament()
+    service = DummyService(t)
+    app.dependency_overrides[get_tournament_service] = lambda: service
+    app.dependency_overrides[get_current_user] = override_user
+    client = TestClient(app)
+    resp = client.post(f"/api/tournaments/{t['id']}/invest", json={"amount": 50})
+    assert resp.status_code == 200
+    assert service.called == (t["id"], "user1", 50)
+    app.dependency_overrides.clear()
+
+
+def test_invest_invalid_amount():
+    t = sample_tournament()
+    service = DummyService(t)
+    app.dependency_overrides[get_tournament_service] = lambda: service
+    app.dependency_overrides[get_current_user] = override_user
+    client = TestClient(app)
+    resp = client.post(f"/api/tournaments/{t['id']}/invest", json={"amount": 0})
+    assert resp.status_code == 400
+    app.dependency_overrides.clear()

--- a/backend/tests/test_tournament_service.py
+++ b/backend/tests/test_tournament_service.py
@@ -1,0 +1,110 @@
+import os
+import pytest
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+# Ensure required env variables for service import
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ex.ex")
+
+from api.services.tournament_service import TournamentService
+
+class DummySupabase:
+    def __init__(self):
+        self.investments = []
+        self.table_name = None
+        self.data = None
+
+    def table(self, name):
+        self.table_name = name
+        return self
+
+    def insert(self, data):
+        self.data = data
+        return self
+
+    def execute(self):
+        if self.table_name == "tournament_investments":
+            self.investments.append(self.data)
+            return type("Resp", (), {"error": None, "data": [self.data]})()
+        return type("Resp", (), {"error": None, "data": []})()
+
+class DummyTournamentService(TournamentService):
+    def __init__(self, tournaments):
+        self.supabase = DummySupabase()
+        self.tournaments = {t["id"]: t for t in tournaments}
+
+    def get_tournament_by_id(self, tournament_id: str):
+        return self.tournaments.get(tournament_id)
+
+    def update_tournament(self, tournament_id: str, update_data):
+        self.tournaments[tournament_id].update(update_data)
+        return self.tournaments[tournament_id]
+
+    def _create_notification(self, *args, **kwargs):
+        pass
+
+
+def sample_tournament(**kwargs):
+    now = datetime.now().isoformat()
+    data = {
+        "id": str(uuid4()),
+        "name": "Test",
+        "description": "desc",
+        "game_type": "Poker",
+        "target_pool_amount": 1000.0,
+        "tournament_buy_in": None,
+        "external_tournament_url": None,
+        "funding_end_time": None,
+        "creator_user_id": str(uuid4()),
+        "player_ranking_at_creation": "BRONZE",
+        "status": "funding_open",
+        "initial_platform_fee_pct": 0.1,
+        "initial_platform_fee_amount": 100.0,
+        "initial_platform_fee_paid": True,
+        "player_guarantee_pct": 0.2,
+        "player_guarantee_amount_required": 200.0,
+        "player_guarantee_paid": True,
+        "winnings_platform_fee_pct": 0.2,
+        "current_pool_amount": 500.0,
+        "total_winnings_from_tournament": None,
+        "platform_winnings_fee_amount": None,
+        "net_winnings_for_investors": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+    data.update(kwargs)
+    return data
+
+
+def test_process_investment_success():
+    tournament = sample_tournament()
+    service = DummyTournamentService([tournament])
+    result = service.process_investment(tournament["id"], "inv1", 100.0)
+    assert result["current_pool_amount"] == pytest.approx(600.0)
+    assert service.supabase.investments[0]["amount"] == 100.0
+    assert result.get("status") == "funding_open"
+
+
+def test_process_investment_pool_complete():
+    tournament = sample_tournament(current_pool_amount=900.0)
+    service = DummyTournamentService([tournament])
+    result = service.process_investment(tournament["id"], "inv1", 100.0)
+    assert result["status"] == "funding_complete"
+    assert result["current_pool_amount"] == pytest.approx(1000.0)
+
+
+def test_process_investment_exceed_target():
+    tournament = sample_tournament(current_pool_amount=950.0)
+    service = DummyTournamentService([tournament])
+    with pytest.raises(Exception):
+        service.process_investment(tournament["id"], "inv1", 100.0)
+
+
+def test_process_investment_after_funding_end():
+    past = datetime.now() - timedelta(days=1)
+    tournament = sample_tournament(funding_end_time=past.isoformat())
+    service = DummyTournamentService([tournament])
+    with pytest.raises(Exception):
+        service.process_investment(tournament["id"], "inv1", 50.0)
+    assert service.tournaments[tournament["id"]]["status"] == "funding_failed"


### PR DESCRIPTION
## Summary
- create `backend/tests/` with pytest
- add tests for `TournamentService.process_investment` and router endpoints
- document test commands in README

## Testing
- `npm run test:backend`

------
https://chatgpt.com/codex/tasks/task_e_686d14003134833099a0fb776eecd315